### PR TITLE
Mobile no margin

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ react-custom-scrollbars
 [![npm downloads](https://img.shields.io/npm/dm/react-custom-scrollbars.svg?style=flat-square)](https://www.npmjs.com/package/react-custom-scrollbars)
 
 * frictionless native browser scrolling
-* native scrollbars for mobile devices
+* native scrollbars for mobile devices (can be disabled)
 * [fully customizable](https://github.com/malte-wessel/react-custom-scrollbars/blob/master/docs/customization.md)
 * [auto hide](https://github.com/malte-wessel/react-custom-scrollbars/blob/master/docs/usage.md#auto-hide)
 * [auto height](https://github.com/malte-wessel/react-custom-scrollbars/blob/master/docs/usage.md#auto-height)
@@ -69,6 +69,7 @@ class CustomScrollbars extends Component {
         autoHeight
         autoHeightMin={0}
         autoHeightMax={200}
+        mobile
         thumbMinSize={30}
         universal={true}
         {...this.props}>

--- a/docs/API.md
+++ b/docs/API.md
@@ -37,6 +37,7 @@
   * When `true` container grows with content
 * `autoHeightMin`: (Number) Set a minimum height for auto-height mode (default: 0)
 * `autoHeightMax`: (Number) Set a maximum height for auto-height mode (default: 200)
+- mobile: (Boolean) Enable to force custom scrollbars on mobile (instead of native)
 * `universal`: (Boolean) Enable universal rendering (default: `false`)
     * [Learn how to use universal rendering](#link)
 

--- a/src/Scrollbars/index.js
+++ b/src/Scrollbars/index.js
@@ -4,7 +4,7 @@ import { Component, createElement, cloneElement } from 'react';
 import PropTypes from 'prop-types';
 
 import isString from '../utils/isString';
-import getScrollbarWidth, { isForcedMobile } from '../utils/getScrollbarWidth';
+import getScrollbarWidth from '../utils/getScrollbarWidth';
 import returnFalse from '../utils/returnFalse';
 import getInnerWidth from '../utils/getInnerWidth';
 import getInnerHeight from '../utils/getInnerHeight';
@@ -13,7 +13,6 @@ import {
     containerStyleDefault,
     containerStyleAutoHeight,
     viewStyleDefault,
-    viewStyleMobile,
     viewStyleAutoHeight,
     viewStyleUniversalInitial,
     trackHorizontalStyleDefault,
@@ -528,13 +527,14 @@ export default class Scrollbars extends Component {
             ...style
         };
 
-        const baseViewStyle = isForcedMobile(mobile) ? viewStyleMobile : viewStyleDefault;
+        // use the true scrollbar width (without any forceMobile hacks) for hiding the true scrollbar
+        const trueScrollbarWidth = getScrollbarWidth(false);
 
         const viewStyle = {
-            ...baseViewStyle,
+            ...viewStyleDefault,
             // Hide scrollbars by setting a negative margin
-            marginRight: scrollbarWidth ? -scrollbarWidth : 0,
-            marginBottom: scrollbarWidth ? -scrollbarWidth : 0,
+            marginRight: -trueScrollbarWidth,
+            marginBottom: -trueScrollbarWidth,
             ...(autoHeight && {
                 ...viewStyleAutoHeight,
                 // Add scrollbarWidth to autoHeight in order to compensate negative margins

--- a/src/Scrollbars/styles.js
+++ b/src/Scrollbars/styles.js
@@ -1,5 +1,3 @@
-import { MOBILE_SCROLLBAR_WIDTH } from '../utils/getScrollbarWidth';
-
 export const containerStyleDefault = {
     position: 'relative',
     overflow: 'hidden',
@@ -18,18 +16,6 @@ export const viewStyleDefault = {
     left: 0,
     right: 0,
     bottom: 0,
-    overflow: 'scroll',
-    WebkitOverflowScrolling: 'touch'
-};
-
-export const viewStyleMobile = {
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    right: 0,
-    bottom: 0,
-    paddingRight: `${MOBILE_SCROLLBAR_WIDTH}px`,
-    paddingBottom: `${MOBILE_SCROLLBAR_WIDTH}px`,
     overflow: 'scroll',
     WebkitOverflowScrolling: 'touch'
 };

--- a/test/Scrollbars/mobile.js
+++ b/test/Scrollbars/mobile.js
@@ -1,7 +1,6 @@
 import { Scrollbars } from 'react-custom-scrollbars';
 import { render, unmountComponentAtNode } from 'react-dom';
 import React from 'react';
-import { MOBILE_SCROLLBAR_WIDTH as scrollbarWidth } from '../../src/utils/getScrollbarWidth';
 export default function createTests(envScrollbarWidth) {
     let node;
     beforeEach(() => {
@@ -24,8 +23,8 @@ export default function createTests(envScrollbarWidth) {
                 setTimeout(() => {
                     const { view } = this;
                     expect(view.style.overflow).toEqual('scroll');
-                    expect(view.style.marginBottom).toEqual(`${-scrollbarWidth}px`);
-                    expect(view.style.marginRight).toEqual(`${-scrollbarWidth}px`);
+                    expect(view.style.marginBottom).toEqual('0px');
+                    expect(view.style.marginRight).toEqual('0px');
                     done();
                 }, 100);
             });


### PR DESCRIPTION
I had some issues with the use of `viewStyleMobile` to avoid negative margins on mobile, so I wrote an alternative implementation. Instead of creating padding to counter the negative margin, I explicitly query the true scrollbar width (ignoring the mobile override) for the purposes of hiding the default scrollbar.

For bonus points I also added documentation for the `mobile` property. Idk if this would help your PR get merged, but it can't hurt.

Feel free to accept part, all, or none of this change. I will likely maintain this fork for my own purposes.